### PR TITLE
Update canvasCollapseIndex.ts: await loadSettings

### DIFF
--- a/src/canvasCollapseIndex.ts
+++ b/src/canvasCollapseIndex.ts
@@ -84,7 +84,7 @@ export default class CanvasCollapsePlugin extends Plugin {
 	settings: CanvasCollapseSettings;
 
 	async onload() {
-		this.loadSettings();
+		await this.loadSettings();
 		this.addSettingTab(new CollapseSettingTab(this.app, this));
 
 		this.registerCommands();


### PR DESCRIPTION
Added "await" to loadSettings to make sure they are ready when read.

It was preventing me from installing the plugin.